### PR TITLE
When both the PDF and PNG features are enabled at the same time, a du…

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -24,8 +24,11 @@ pub(crate) fn estimate_text_width(text: &str, font_size: f64) -> f64 {
 }
 
 // =============================== Font Database Utilities =====================================
+#[cfg(any(feature = "png", feature = "pdf"))]
+use std::sync::OnceLock;
+
 #[cfg(feature = "pdf")]
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 /// Global cache for the font database to avoid expensive system scans on every render.
 /// We use Arc to allow thread-safe sharing across multiple chart generation tasks.
@@ -68,7 +71,7 @@ pub(crate) fn get_font_db() -> Arc<svg2pdf::usvg::fontdb::Database> {
 #[cfg(feature = "png")]
 use ab_glyph::FontArc;
 #[cfg(feature = "png")]
-use std::sync::{OnceLock, RwLock};
+use std::sync::RwLock;
 
 /// Global cache for raster fonts.
 /// Maps lowercase font family names to FontArc instances.


### PR DESCRIPTION
…plicate import error occurs for the type OnceLock.

 --> .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/charton-0.5.7/src/core/utils.rs:71:17
   |
28 | use std::sync::{Arc, OnceLock};
   |                      -------- previous import of the type `OnceLock` here
...
71 | use std::sync::{OnceLock, RwLock};
   |                 ^^^^^^^^--
   |                 |
   |                 `OnceLock` reimported here
   |                 help: remove unnecessary import
   |
   = note: `OnceLock` must be defined only once in the type namespace of this module