### PR TITLE
const fn

### DIFF
--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -19,7 +19,7 @@ pub struct Rect {
 }
 
 impl Rect {
-    pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+    pub const fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
         Self {
             x,
             y,

--- a/src/core/aesthetics.rs
+++ b/src/core/aesthetics.rs
@@ -35,7 +35,7 @@ impl GlobalAesthetics {
     ///
     /// This is typically invoked after the "Scale Training" phase, where
     /// data domains from all layers have been aggregated.
-    pub fn new(
+    pub const fn new(
         color: Option<AestheticMapping>,
         shape: Option<AestheticMapping>,
         size: Option<AestheticMapping>,

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -85,12 +85,12 @@ impl<'a> PanelContext<'a> {
     }
 
     /// Provides direct access to the global theme.
-    pub fn theme(&self) -> &Theme {
+    pub const fn theme(&self) -> &Theme {
         self.spec.theme
     }
 
     /// Provides direct access to the global aesthetic scales.
-    pub fn aesthetics(&self) -> &GlobalAesthetics {
+    pub const fn aesthetics(&self) -> &GlobalAesthetics {
         self.spec.aesthetics
     }
 }

--- a/src/core/data.rs
+++ b/src/core/data.rs
@@ -142,7 +142,7 @@ impl ColumnVector {
     ///
     /// This is the preferred method for bridges (like Polars) where data is
     /// already physically separated into indices and values.
-    pub fn from_categorical(
+    pub const fn from_categorical(
         keys: Vec<u32>,
         values: Vec<String>,
         validity: Option<Vec<u8>>,
@@ -233,7 +233,7 @@ impl ColumnVector {
     ///
     /// This is a low-latency operation used to guide the selection of
     /// visual encoding strategies (e.g., choosing a TemporalScale for Datetime).
-    pub fn semantic_type(&self) -> SemanticType {
+    pub const fn semantic_type(&self) -> SemanticType {
         match self {
             // --- Continuous: Measurable numeric values ---
             ColumnVector::Float64 { .. }
@@ -263,7 +263,7 @@ impl ColumnVector {
     ///
     /// This is used primarily for diagnostic printing and debugging,
     /// allowing users to quickly identify the physical storage of a column.
-    pub fn dtype_name(&self) -> &'static str {
+    pub const fn dtype_name(&self) -> &'static str {
         match self {
             // --- Floats ---
             ColumnVector::Float64 { .. } => "f64",
@@ -298,7 +298,7 @@ impl ColumnVector {
     }
 
     /// Returns the number of rows in this column.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         match self {
             // Standard numeric and boolean types
             ColumnVector::Boolean { data, .. } => data.len(),
@@ -331,7 +331,7 @@ impl ColumnVector {
     /// This is the preferred way to check for empty columns in Rust
     /// as it aligns with standard library collection APIs.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -890,7 +890,7 @@ impl ColumnVector {
     ///
     /// The bitmask uses a packed `u8` format where each bit represents the
     /// validity of a row (1 for Valid, 0 for Null).
-    pub fn get_validity_mask(&self) -> &Option<Vec<u8>> {
+    pub const fn get_validity_mask(&self) -> &Option<Vec<u8>> {
         match self {
             ColumnVector::Float64 { validity, .. } => validity,
             ColumnVector::Float32 { validity, .. } => validity,
@@ -2256,7 +2256,7 @@ impl Dataset {
     }
 
     /// Returns true if the dataset has no rows.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.row_count == 0
     }
 
@@ -2307,12 +2307,12 @@ impl Dataset {
     }
 
     /// Returns the number of rows in the dataset.
-    pub fn height(&self) -> usize {
+    pub const fn height(&self) -> usize {
         self.row_count
     }
 
     /// Returns the number of columns in the dataset.
-    pub fn width(&self) -> usize {
+    pub const fn width(&self) -> usize {
         self.columns.len()
     }
 
@@ -3048,7 +3048,7 @@ pub struct RowAccessor<'a> {
 
 impl<'a> RowAccessor<'a> {
     /// Creates a new RowAccessor for a specific row.
-    pub fn new(ds: &'a Dataset, row: usize) -> Self {
+    pub const fn new(ds: &'a Dataset, row: usize) -> Self {
         Self {
             ds,
             current_row: row,
@@ -3070,7 +3070,7 @@ impl<'a> RowAccessor<'a> {
     }
 
     /// Returns the current row index.
-    pub fn index(&self) -> usize {
+    pub const fn index(&self) -> usize {
         self.current_row
     }
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -60,7 +60,7 @@ impl Encoding {
     ///
     /// This is used by the Chart state machine to determine if validation
     /// and data transformation should be triggered during a mark transition.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.x.is_none()
             && self.y.is_none()
             && self.y2.is_none()

--- a/src/encode/color.rs
+++ b/src/encode/color.rs
@@ -55,7 +55,7 @@ impl Color {
     }
 
     /// Explicitly sets the scale type for color mapping (e.g., Linear, Log).
-    pub fn with_scale(mut self, scale_type: Scale) -> Self {
+    pub const fn with_scale(mut self, scale_type: Scale) -> Self {
         self.scale_type = Some(scale_type);
         self
     }
@@ -67,7 +67,7 @@ impl Color {
     }
 
     /// Configures the expansion padding for the color scale.
-    pub fn with_expandsion(mut self, expansion: Expansion) -> Self {
+    pub const fn with_expandsion(mut self, expansion: Expansion) -> Self {
         self.expansion = Some(expansion);
         self
     }

--- a/src/encode/shape.rs
+++ b/src/encode/shape.rs
@@ -46,7 +46,7 @@ impl Shape {
     }
 
     /// Sets the desired scale type. Usually kept as Discrete for shapes.
-    pub fn with_scale(mut self, scale_type: Scale) -> Self {
+    pub const fn with_scale(mut self, scale_type: Scale) -> Self {
         self.scale_type = Some(scale_type);
         self
     }
@@ -60,7 +60,7 @@ impl Shape {
     }
 
     /// Configures the expansion padding (spacing) for the categorical axis.
-    pub fn with_expansion(mut self, expansion: Expansion) -> Self {
+    pub const fn with_expansion(mut self, expansion: Expansion) -> Self {
         self.expansion = Some(expansion);
         self
     }

--- a/src/encode/size.rs
+++ b/src/encode/size.rs
@@ -68,7 +68,7 @@ impl Size {
     }
 
     /// Configures the expansion padding for the size scale.
-    pub fn with_expansion(mut self, expansion: Expansion) -> Self {
+    pub const fn with_expansion(mut self, expansion: Expansion) -> Self {
         self.expansion = Some(expansion);
         self
     }

--- a/src/encode/x.rs
+++ b/src/encode/x.rs
@@ -53,7 +53,7 @@ impl X {
     }
 
     /// Sets the preferred scale type (e.g., `Scale::Linear`, `Scale::Log`).
-    pub fn with_scale(mut self, scale_type: Scale) -> Self {
+    pub const fn with_scale(mut self, scale_type: Scale) -> Self {
         self.scale_type = Some(scale_type);
         self
     }
@@ -68,13 +68,13 @@ impl X {
     }
 
     /// Configures the expansion padding for the axis.
-    pub fn with_expansion(mut self, expansion: Expansion) -> Self {
+    pub const fn with_expansion(mut self, expansion: Expansion) -> Self {
         self.expansion = Some(expansion);
         self
     }
 
     /// Determines if the scale must include the zero value.
-    pub fn with_zero(mut self, zero: bool) -> Self {
+    pub const fn with_zero(mut self, zero: bool) -> Self {
         self.zero = Some(zero);
         self
     }
@@ -90,7 +90,7 @@ impl X {
     ///
     /// # Returns
     /// Returns `Self` with the updated bin count
-    pub fn with_bins(mut self, bins: usize) -> Self {
+    pub const fn with_bins(mut self, bins: usize) -> Self {
         self.bins = Some(bins);
         self
     }

--- a/src/encode/y.rs
+++ b/src/encode/y.rs
@@ -108,7 +108,7 @@ impl Y {
     }
 
     /// Sets the desired scale type (e.g., `Scale::Linear`, `Scale::Log`).
-    pub fn with_scale(mut self, scale_type: Scale) -> Self {
+    pub const fn with_scale(mut self, scale_type: Scale) -> Self {
         self.scale_type = Some(scale_type);
         self
     }
@@ -122,13 +122,13 @@ impl Y {
     }
 
     /// Configures the expansion padding for the axis.
-    pub fn with_expansion(mut self, expansion: Expansion) -> Self {
+    pub const fn with_expansion(mut self, expansion: Expansion) -> Self {
         self.expansion = Some(expansion);
         self
     }
 
     /// Determines if the scale must include the zero value.
-    pub fn with_zero(mut self, zero: bool) -> Self {
+    pub const fn with_zero(mut self, zero: bool) -> Self {
         self.zero = Some(zero);
         self
     }
@@ -144,7 +144,7 @@ impl Y {
     ///
     /// # Returns
     /// Returns `Self` with the updated bin count
-    pub fn with_bins(mut self, bins: usize) -> Self {
+    pub const fn with_bins(mut self, bins: usize) -> Self {
         self.bins = Some(bins);
         self
     }
@@ -162,7 +162,7 @@ impl Y {
     ///
     /// # Returns
     /// Returns `Self` with the updated normalization setting
-    pub fn with_normalize(mut self, normalize: bool) -> Self {
+    pub const fn with_normalize(mut self, normalize: bool) -> Self {
         self.normalize = normalize;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! facilitates the creation of informative and aesthetically pleasing visualizations interactively,
 //! making it especially well-suited for exploratory data analysis.
 
+#![warn(clippy::missing_const_for_fn)]
+
 pub mod chart;
 pub mod coordinate;
 pub mod core;

--- a/src/mark/area.rs
+++ b/src/mark/area.rs
@@ -38,7 +38,7 @@ impl MarkArea {
     /// Sets the opacity of the area mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
@@ -50,7 +50,7 @@ impl MarkArea {
     }
 
     /// Sets the thickness of the area's boundary stroke.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = width;
         self
     }

--- a/src/mark/bar.rs
+++ b/src/mark/bar.rs
@@ -52,7 +52,7 @@ impl MarkBar {
     }
 
     /// Sets the opacity of the bar mark (0.0 to 1.0).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
@@ -64,7 +64,7 @@ impl MarkBar {
     }
 
     /// Sets the thickness of the bar's outline in pixels.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = Some(width);
         self
     }
@@ -72,19 +72,19 @@ impl MarkBar {
     /// Manually sets the width of a bar.
     ///
     /// Providing a value here will override the coordinate system's default suggestion.
-    pub fn with_width(mut self, width: f64) -> Self {
+    pub const fn with_width(mut self, width: f64) -> Self {
         self.width = Some(width.clamp(0.0, 1.0));
         self
     }
 
     /// Manually sets the relative spacing between bars within a group (0.0 to 1.0).
-    pub fn with_spacing(mut self, spacing: f64) -> Self {
+    pub const fn with_spacing(mut self, spacing: f64) -> Self {
         self.spacing = Some(spacing.clamp(0.0, 1.0));
         self
     }
 
     /// Manually sets the total span of a bar group within a category (0.0 to 1.0).
-    pub fn with_span(mut self, span: f64) -> Self {
+    pub const fn with_span(mut self, span: f64) -> Self {
         self.span = Some(span.clamp(0.0, 1.0));
         self
     }

--- a/src/mark/boxplot.rs
+++ b/src/mark/boxplot.rs
@@ -49,7 +49,7 @@ impl MarkBoxplot {
     /// Sets the opacity of the boxplot mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
@@ -61,7 +61,7 @@ impl MarkBoxplot {
     }
 
     /// Sets the thickness of the boxplot's lines.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = width;
         self
     }
@@ -73,19 +73,19 @@ impl MarkBoxplot {
     }
 
     /// Enables or disables the display of outlier points.
-    pub fn with_outliers(mut self, show: bool) -> Self {
+    pub const fn with_outliers(mut self, show: bool) -> Self {
         self.show_outliers = show;
         self
     }
 
     /// Sets the size of the outlier points.
-    pub fn with_outlier_size(mut self, size: f64) -> Self {
+    pub const fn with_outlier_size(mut self, size: f64) -> Self {
         self.outlier_size = size;
         self
     }
 
     /// Sets the maximal width of the boxes.
-    pub fn with_width(mut self, width: f64) -> Self {
+    pub const fn with_width(mut self, width: f64) -> Self {
         self.width = width;
         self
     }
@@ -93,7 +93,7 @@ impl MarkBoxplot {
     /// Sets the relative spacing between boxes in a group.
     ///
     /// Value is clamped between 0.0 and 1.0.
-    pub fn with_spacing(mut self, spacing: f64) -> Self {
+    pub const fn with_spacing(mut self, spacing: f64) -> Self {
         self.spacing = spacing.clamp(0.0, 1.0);
         self
     }
@@ -101,7 +101,7 @@ impl MarkBoxplot {
     /// Sets the total span allocated for a box group.
     ///
     /// Value is clamped between 0.0 and 1.0.
-    pub fn with_span(mut self, span: f64) -> Self {
+    pub const fn with_span(mut self, span: f64) -> Self {
         self.span = span.clamp(0.0, 1.0);
         self
     }

--- a/src/mark/errorbar.rs
+++ b/src/mark/errorbar.rs
@@ -46,43 +46,43 @@ impl MarkErrorBar {
     /// Sets the opacity of the error bar mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
 
     /// Sets the thickness of the error bar lines.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = width;
         self
     }
 
     /// Sets the length of the horizontal caps at the ends of the error bar.
-    pub fn with_cap_length(mut self, length: f64) -> Self {
+    pub const fn with_cap_length(mut self, length: f64) -> Self {
         self.cap_length = length;
         self
     }
 
     /// Determines whether to display a marker at the center (mean/median) of the error bar.
-    pub fn with_center(mut self, show: bool) -> Self {
+    pub const fn with_center(mut self, show: bool) -> Self {
         self.show_center = show;
         self
     }
 
     /// Sets the relative width of the marks.
-    pub fn with_width(mut self, width: f64) -> Self {
+    pub const fn with_width(mut self, width: f64) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the spacing between marks in a grouped layout.
-    pub fn with_spacing(mut self, spacing: f64) -> Self {
+    pub const fn with_spacing(mut self, spacing: f64) -> Self {
         self.spacing = spacing.clamp(0.0, 1.0);
         self
     }
 
     /// Sets the total span of the group within a category.
-    pub fn with_span(mut self, span: f64) -> Self {
+    pub const fn with_span(mut self, span: f64) -> Self {
         self.span = span.clamp(0.0, 1.0);
         self
     }

--- a/src/mark/histogram.rs
+++ b/src/mark/histogram.rs
@@ -36,7 +36,7 @@ impl MarkHist {
     /// Sets the opacity of the histogram mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
@@ -48,7 +48,7 @@ impl MarkHist {
     }
 
     /// Sets the thickness of the bar's outline.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = width;
         self
     }

--- a/src/mark/line.rs
+++ b/src/mark/line.rs
@@ -40,7 +40,7 @@ impl MarkLine {
     }
 
     /// Sets the thickness of the line.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = width;
         self
     }
@@ -63,7 +63,7 @@ impl MarkLine {
     /// Sets the opacity of the line mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
@@ -77,7 +77,7 @@ impl MarkLine {
     }
 
     /// Enables or disables LOESS (Locally Estimated Scatterplot Smoothing).
-    pub fn with_loess(mut self, use_loess: bool) -> Self {
+    pub const fn with_loess(mut self, use_loess: bool) -> Self {
         self.loess = use_loess;
         self
     }
@@ -85,7 +85,7 @@ impl MarkLine {
     /// Sets the bandwidth parameter for LOESS smoothing.
     ///
     /// Controls the smoothness; value should be between 0.0 and 1.0.
-    pub fn with_loess_bandwidth(mut self, bandwidth: f64) -> Self {
+    pub const fn with_loess_bandwidth(mut self, bandwidth: f64) -> Self {
         self.loess_bandwidth = bandwidth.clamp(0.0, 1.0);
         self
     }

--- a/src/mark/point.rs
+++ b/src/mark/point.rs
@@ -87,7 +87,7 @@ impl MarkPoint {
     }
 
     /// Sets the size (radius or scale factor) of the point.
-    pub fn with_size(mut self, size: f64) -> Self {
+    pub const fn with_size(mut self, size: f64) -> Self {
         self.size = size;
         self
     }
@@ -95,7 +95,7 @@ impl MarkPoint {
     /// Sets the opacity of the point mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
@@ -107,7 +107,7 @@ impl MarkPoint {
     }
 
     /// Sets the thickness of the point's outline.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = width;
         self
     }
@@ -121,19 +121,19 @@ impl MarkPoint {
     }
 
     /// Sets the relative width of the marks.
-    pub fn with_width(mut self, width: f64) -> Self {
+    pub const fn with_width(mut self, width: f64) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the spacing between marks in a grouped layout.
-    pub fn with_spacing(mut self, spacing: f64) -> Self {
+    pub const fn with_spacing(mut self, spacing: f64) -> Self {
         self.spacing = spacing.clamp(0.0, 1.0);
         self
     }
 
     /// Sets the total span of the group within a category.
-    pub fn with_span(mut self, span: f64) -> Self {
+    pub const fn with_span(mut self, span: f64) -> Self {
         self.span = span.clamp(0.0, 1.0);
         self
     }

--- a/src/mark/rect.rs
+++ b/src/mark/rect.rs
@@ -36,7 +36,7 @@ impl MarkRect {
     /// Sets the opacity of the rectangle mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
@@ -48,7 +48,7 @@ impl MarkRect {
     }
 
     /// Sets the thickness of the rectangle's outline.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = width;
         self
     }

--- a/src/mark/rule.rs
+++ b/src/mark/rule.rs
@@ -35,13 +35,13 @@ impl MarkRule {
     /// Sets the opacity of the rule line.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }
 
     /// Sets the thickness of the rule line.
-    pub fn with_stroke_width(mut self, width: f64) -> Self {
+    pub const fn with_stroke_width(mut self, width: f64) -> Self {
         self.stroke_width = width;
         self
     }

--- a/src/mark/text.rs
+++ b/src/mark/text.rs
@@ -112,7 +112,7 @@ impl MarkText {
     }
 
     /// Sets the font size of the text.
-    pub fn with_size(mut self, size: f64) -> Self {
+    pub const fn with_size(mut self, size: f64) -> Self {
         self.font_size = size;
         self
     }
@@ -138,7 +138,7 @@ impl MarkText {
     /// Sets the opacity of the text mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }

--- a/src/mark/tick.rs
+++ b/src/mark/tick.rs
@@ -54,7 +54,7 @@ impl MarkTick {
     /// ```rust,ignore
     /// chart.mark_tick()?.configure_tick(|m| m.thickness(2.0))
     /// ```
-    pub fn with_thickness(mut self, thickness: f64) -> Self {
+    pub const fn with_thickness(mut self, thickness: f64) -> Self {
         self.thickness = thickness.max(0.0);
         self
     }
@@ -68,7 +68,7 @@ impl MarkTick {
     /// ```rust,ignore
     /// chart.mark_tick()?.configure_tick(|m| m.band_size(10.0))
     /// ```
-    pub fn with_band_size(mut self, band_size: f64) -> Self {
+    pub const fn with_band_size(mut self, band_size: f64) -> Self {
         self.band_size = band_size.max(0.0);
         self
     }
@@ -76,7 +76,7 @@ impl MarkTick {
     /// Sets the opacity of the tick mark.
     ///
     /// Value should be between 0.0 (transparent) and 1.0 (opaque).
-    pub fn with_opacity(mut self, opacity: f64) -> Self {
+    pub const fn with_opacity(mut self, opacity: f64) -> Self {
         self.opacity = opacity.clamp(0.0, 1.0);
         self
     }

--- a/src/scale/discrete.rs
+++ b/src/scale/discrete.rs
@@ -66,7 +66,7 @@ impl DiscreteScale {
     }
 
     /// Returns the total number of categories in the domain.
-    pub fn count(&self) -> usize {
+    pub const fn count(&self) -> usize {
         self.domain.len()
     }
 }

--- a/src/scale/linear.rs
+++ b/src/scale/linear.rs
@@ -25,7 +25,7 @@ impl LinearScale {
     /// # Arguments
     /// * `domain` - A tuple of (min, max) representing the expanded data range.
     /// * `mapper` - An optional `VisualMapper` for non-positional aesthetics.
-    pub fn new(domain: (f64, f64), mapper: Option<VisualMapper>) -> Self {
+    pub const fn new(domain: (f64, f64), mapper: Option<VisualMapper>) -> Self {
         Self { domain, mapper }
     }
 

--- a/src/scale/log.rs
+++ b/src/scale/log.rs
@@ -57,7 +57,7 @@ impl LogScale {
     }
 
     /// Returns the logarithm base used by this scale.
-    pub fn base(&self) -> f64 {
+    pub const fn base(&self) -> f64 {
         self.base
     }
 }

--- a/src/scale/mapper.rs
+++ b/src/scale/mapper.rs
@@ -41,12 +41,12 @@ impl VisualMapper {
     }
 
     /// Creates a default size mapper with a specified physical range.
-    pub fn new_size_default(min: f64, max: f64) -> Self {
+    pub const fn new_size_default(min: f64, max: f64) -> Self {
         VisualMapper::Size { range: (min, max) }
     }
 
     /// Creates a default shape mapper using the standard geometric shapes.
-    pub fn new_shape_default() -> Self {
+    pub const fn new_shape_default() -> Self {
         VisualMapper::Shape {
             custom_shapes: None,
         }

--- a/src/scale/temporal.rs
+++ b/src/scale/temporal.rs
@@ -55,7 +55,7 @@ const TICK_LADDER: &[(Duration, &str)] = &[
 ];
 
 impl TemporalScale {
-    pub fn new(domain: (i64, i64), mapper: Option<VisualMapper>) -> Self {
+    pub const fn new(domain: (i64, i64), mapper: Option<VisualMapper>) -> Self {
         Self { domain, mapper }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -135,34 +135,34 @@ impl Theme {
         self
     }
 
-    pub fn with_top_margin(mut self, margin: f64) -> Self {
+    pub const fn with_top_margin(mut self, margin: f64) -> Self {
         self.top_margin = margin;
         self
     }
 
-    pub fn with_right_margin(mut self, margin: f64) -> Self {
+    pub const fn with_right_margin(mut self, margin: f64) -> Self {
         self.right_margin = margin;
         self
     }
 
-    pub fn with_bottom_margin(mut self, margin: f64) -> Self {
+    pub const fn with_bottom_margin(mut self, margin: f64) -> Self {
         self.bottom_margin = margin;
         self
     }
 
-    pub fn with_left_margin(mut self, margin: f64) -> Self {
+    pub const fn with_left_margin(mut self, margin: f64) -> Self {
         self.left_margin = margin;
         self
     }
 
-    pub fn with_show_axes(mut self, show: bool) -> Self {
+    pub const fn with_show_axes(mut self, show: bool) -> Self {
         self.show_axes = show;
         self
     }
 
     // --- Title ---
 
-    pub fn with_title_size(mut self, size: f64) -> Self {
+    pub const fn with_title_size(mut self, size: f64) -> Self {
         self.title_size = size;
         self
     }
@@ -179,7 +179,7 @@ impl Theme {
 
     // --- Axis Label ---
 
-    pub fn with_label_size(mut self, size: f64) -> Self {
+    pub const fn with_label_size(mut self, size: f64) -> Self {
         self.label_size = size;
         self
     }
@@ -194,14 +194,14 @@ impl Theme {
         self
     }
 
-    pub fn with_label_padding(mut self, padding: f64) -> Self {
+    pub const fn with_label_padding(mut self, padding: f64) -> Self {
         self.label_padding = padding;
         self
     }
 
     // --- Tick Label ---
 
-    pub fn with_tick_label_size(mut self, size: f64) -> Self {
+    pub const fn with_tick_label_size(mut self, size: f64) -> Self {
         self.tick_label_size = size;
         self
     }
@@ -216,51 +216,51 @@ impl Theme {
         self
     }
 
-    pub fn with_tick_label_padding(mut self, padding: f64) -> Self {
+    pub const fn with_tick_label_padding(mut self, padding: f64) -> Self {
         self.tick_label_padding = padding;
         self
     }
 
-    pub fn with_x_tick_label_angle(mut self, angle: f64) -> Self {
+    pub const fn with_x_tick_label_angle(mut self, angle: f64) -> Self {
         self.x_tick_label_angle = angle;
         self
     }
 
-    pub fn with_y_tick_label_angle(mut self, angle: f64) -> Self {
+    pub const fn with_y_tick_label_angle(mut self, angle: f64) -> Self {
         self.y_tick_label_angle = angle;
         self
     }
 
     // --- Geometry Strokes ---
 
-    pub fn with_axis_width(mut self, width: f64) -> Self {
+    pub const fn with_axis_width(mut self, width: f64) -> Self {
         self.axis_width = width;
         self
     }
 
-    pub fn with_tick_width(mut self, width: f64) -> Self {
+    pub const fn with_tick_width(mut self, width: f64) -> Self {
         self.tick_width = width;
         self
     }
 
-    pub fn with_tick_length(mut self, length: f64) -> Self {
+    pub const fn with_tick_length(mut self, length: f64) -> Self {
         self.tick_length = length;
         self
     }
 
-    pub fn with_tick_min_spacing(mut self, spacing: f64) -> Self {
+    pub const fn with_tick_min_spacing(mut self, spacing: f64) -> Self {
         self.tick_min_spacing = spacing;
         self
     }
 
     // --- Legend Styling ---
 
-    pub fn with_legend_title_size(mut self, size: f64) -> Self {
+    pub const fn with_legend_title_size(mut self, size: f64) -> Self {
         self.legend_title_size = size;
         self
     }
 
-    pub fn with_legend_label_size(mut self, size: f64) -> Self {
+    pub const fn with_legend_label_size(mut self, size: f64) -> Self {
         self.legend_label_size = size;
         self
     }
@@ -275,63 +275,63 @@ impl Theme {
         self
     }
 
-    pub fn with_legend_block_gap(mut self, gap: f64) -> Self {
+    pub const fn with_legend_block_gap(mut self, gap: f64) -> Self {
         self.legend_block_gap = gap;
         self
     }
 
-    pub fn with_legend_item_v_gap(mut self, gap: f64) -> Self {
+    pub const fn with_legend_item_v_gap(mut self, gap: f64) -> Self {
         self.legend_item_v_gap = gap;
         self
     }
 
-    pub fn with_legend_col_h_gap(mut self, gap: f64) -> Self {
+    pub const fn with_legend_col_h_gap(mut self, gap: f64) -> Self {
         self.legend_col_h_gap = gap;
         self
     }
 
-    pub fn with_legend_title_gap(mut self, gap: f64) -> Self {
+    pub const fn with_legend_title_gap(mut self, gap: f64) -> Self {
         self.legend_title_gap = gap;
         self
     }
 
-    pub fn with_legend_marker_text_gap(mut self, gap: f64) -> Self {
+    pub const fn with_legend_marker_text_gap(mut self, gap: f64) -> Self {
         self.legend_marker_text_gap = gap;
         self
     }
 
     // --- Legend Logic ---
 
-    pub fn with_legend_position(mut self, position: LegendPosition) -> Self {
+    pub const fn with_legend_position(mut self, position: LegendPosition) -> Self {
         self.legend_position = position;
         self
     }
 
-    pub fn with_legend_margin(mut self, margin: f64) -> Self {
+    pub const fn with_legend_margin(mut self, margin: f64) -> Self {
         self.legend_margin = margin;
         self
     }
 
     // --- Layout Defense ---
 
-    pub fn with_min_panel_size(mut self, size: f64) -> Self {
+    pub const fn with_min_panel_size(mut self, size: f64) -> Self {
         self.min_panel_size = size;
         self
     }
 
-    pub fn with_panel_defense_ratio(mut self, ratio: f64) -> Self {
+    pub const fn with_panel_defense_ratio(mut self, ratio: f64) -> Self {
         self.panel_defense_ratio = ratio;
         self
     }
 
-    pub fn with_axis_reserve_buffer(mut self, buffer: f64) -> Self {
+    pub const fn with_axis_reserve_buffer(mut self, buffer: f64) -> Self {
         self.axis_reserve_buffer = buffer;
         self
     }
 
     // --- Color & Palette Defaults ---
 
-    pub fn with_color_map(mut self, map: ColorMap) -> Self {
+    pub const fn with_color_map(mut self, map: ColorMap) -> Self {
         self.color_map = map;
         self
     }
@@ -343,7 +343,7 @@ impl Theme {
 
     // --- Facet Styling ---
     /// The font size for the facet labels (the text in the strip).
-    pub fn with_facet_label_size(mut self, size: f64) -> Self {
+    pub const fn with_facet_label_size(mut self, size: f64) -> Self {
         self.facet_label_size = size;
         self
     }
@@ -361,12 +361,12 @@ impl Theme {
     }
 
     /// The spacing between individual facet panels (both horizontal and vertical).
-    pub fn with_facet_spacing(mut self, spacing: f64) -> Self {
+    pub const fn with_facet_spacing(mut self, spacing: f64) -> Self {
         self.facet_spacing = spacing;
         self
     }
     /// The padding inside the facet strip.
-    pub fn with_facet_strip_padding(mut self, padding: f64) -> Self {
+    pub const fn with_facet_strip_padding(mut self, padding: f64) -> Self {
         self.facet_strip_padding = padding;
         self
     }
@@ -383,7 +383,7 @@ impl Theme {
         self
     }
 
-    pub fn with_grid_width(mut self, width: f64) -> Self {
+    pub const fn with_grid_width(mut self, width: f64) -> Self {
         self.grid_width = width;
         self
     }

--- a/src/transform/density_transform.rs
+++ b/src/transform/density_transform.rs
@@ -23,7 +23,7 @@ pub enum KernelType {
 }
 
 impl KernelType {
-    fn as_str(&self) -> &'static str {
+    const fn as_str(&self) -> &'static str {
         match self {
             KernelType::Normal => "Normal",
             KernelType::Epanechnikov => "Epanechnikov",
@@ -57,7 +57,7 @@ pub enum BandwidthType {
 }
 
 impl BandwidthType {
-    fn as_str(&self) -> &'static str {
+    const fn as_str(&self) -> &'static str {
         match self {
             BandwidthType::Scott => "Scott",
             BandwidthType::Silverman => "Silverman",
@@ -160,7 +160,7 @@ impl DensityTransform {
     /// let transform = DensityTransform::new("data")
     ///     .with_bandwidth(BandwidthType::Silverman);
     /// ```
-    pub fn with_bandwidth(mut self, bandwidth: BandwidthType) -> Self {
+    pub const fn with_bandwidth(mut self, bandwidth: BandwidthType) -> Self {
         self.bandwidth = bandwidth;
         self
     }
@@ -178,7 +178,7 @@ impl DensityTransform {
     /// let transform = DensityTransform::new("data")
     ///     .with_counts(true); // Output smoothed counts instead of probabilities
     /// ```
-    pub fn with_counts(mut self, counts: bool) -> Self {
+    pub const fn with_counts(mut self, counts: bool) -> Self {
         self.counts = counts;
         self
     }
@@ -196,7 +196,7 @@ impl DensityTransform {
     /// let transform = DensityTransform::new("data")
     ///     .with_cumulative(true); // Output cumulative density instead of regular density
     /// ```
-    pub fn with_cumulative(mut self, cumulative: bool) -> Self {
+    pub const fn with_cumulative(mut self, cumulative: bool) -> Self {
         self.cumulative = cumulative;
         self
     }

--- a/src/transform/window_transform.rs
+++ b/src/transform/window_transform.rs
@@ -38,7 +38,7 @@ pub enum WindowOnlyOp {
 }
 
 impl WindowOnlyOp {
-    fn as_str(&self) -> &'static str {
+    const fn as_str(&self) -> &'static str {
         match self {
             WindowOnlyOp::RowNumber => "row_number",
             WindowOnlyOp::Rank => "rank",
@@ -136,7 +136,7 @@ impl WindowTransform {
     /// let window_field = WindowFieldDef::new("value", WindowOnlyOp::Rank, "value_rank");
     /// let window_transform = WindowTransform::new(window_field);
     /// ```
-    pub fn new(window: WindowFieldDef) -> Self {
+    pub const fn new(window: WindowFieldDef) -> Self {
         Self {
             window,
             frame: [None, Some(0.0)], // Default value: [null, 0]
@@ -159,7 +159,7 @@ impl WindowTransform {
     /// ```rust,ignore
     /// let window_transform = window_transform.with_frame([Some(-5.0), Some(5.0)]); // Window includes 5 rows before and after
     /// ```
-    pub fn with_frame(mut self, frame: [Option<f64>; 2]) -> Self {
+    pub const fn with_frame(mut self, frame: [Option<f64>; 2]) -> Self {
         self.frame = frame;
         self
     }
@@ -193,7 +193,7 @@ impl WindowTransform {
     /// ```rust,ignore
     /// let window_transform = window_transform.with_ignore_peers(true);
     /// ```
-    pub fn with_ignore_peers(mut self, ignore_peers: bool) -> Self {
+    pub const fn with_ignore_peers(mut self, ignore_peers: bool) -> Self {
         self.ignore_peers = ignore_peers;
         self
     }
@@ -210,7 +210,7 @@ impl WindowTransform {
     /// ```rust,ignore
     /// let window_transform = window_transform.with_normalize(true);
     /// ```
-    pub fn with_normalize(mut self, normalize: bool) -> Self {
+    pub const fn with_normalize(mut self, normalize: bool) -> Self {
         self.normalize = normalize;
         self
     }

--- a/src/visual/color.rs
+++ b/src/visual/color.rs
@@ -736,13 +736,13 @@ impl SingleColor {
         }
     }
 
-    pub fn none() -> Self {
+    pub const fn none() -> Self {
         Self {
             rgba: [0.0, 0.0, 0.0, 0.0],
         }
     }
 
-    pub fn from_rgba(r: f64, g: f64, b: f64, a: f64) -> Self {
+    pub const fn from_rgba(r: f64, g: f64, b: f64, a: f64) -> Self {
         Self {
             rgba: [
                 r.clamp(0.0, 1.0) as Precision,
@@ -753,7 +753,7 @@ impl SingleColor {
         }
     }
 
-    pub fn rgba(&self) -> [Precision; 4] {
+    pub const fn rgba(&self) -> [Precision; 4] {
         self.rgba
     }
 

--- a/src/visual/shape.rs
+++ b/src/visual/shape.rs
@@ -18,7 +18,7 @@ pub enum PointShape {
 impl PointShape {
     /// Returns a unique integer ID for the shape.
     /// This is crucial for passing shape data to GPU shaders (wgpu).
-    pub fn gpu_id(&self) -> u32 {
+    pub const fn gpu_id(&self) -> u32 {
         *self as u32
     }
 


### PR DESCRIPTION
I’d like to port some themes from ggplot2, for example  [theme_economist](https://jrnold.github.io/ggthemes/reference/theme_economist.html) from ggthemes￼.

I also found that many functions can be made const. This is a separate PR, which adds `#![warn(clippy::missing_const_for_fn)]` in `lib.rs`.

I ran into a problem while constructing themes: I can’t add anything to `ColorMap`. Unlike `ColorPalette`, it doesn’t support custom entries.

